### PR TITLE
Upgrade to 4.2.6

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'aquaskk' do
-  version '4.2.4'
+  version '4.2.6'
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
-  sha256 'cec143d122c8227e4e6487c9f28eb7d76a3c103e8c2d82e674b7b98fd912fcd5'
+  sha256 '422265fad2c9362fd491b06fa06cbc2b307b2605137533131b0c67e974fac1ec'
   license :gpl # GPL v2
   pkg 'AquaSKK.pkg'
   uninstall :pkgutil => 'jp.sourceforge.inputmethod.aquaskk.pkg'


### PR DESCRIPTION
Follow an [update of upstream package](https://github.com/codefirst/aquaskk/releases/tag/4.2.6).

---

The sha-256 calculation the following.

    $ openssl dgst -sha256 ~/Downloads/AquaSKK-4.2.6.dmg
    SHA256(/Users/takeru/Downloads/AquaSKK-4.2.6.dmg)= 422265fad2c9362fd491b06fa06cbc2b307b2605137533131b0c67e974fac1ec