### PR TITLE
Upgrade to 4.2.7

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'aquaskk' do
-  version '4.2.4'
+  version '4.2.7'
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
-  sha256 'cec143d122c8227e4e6487c9f28eb7d76a3c103e8c2d82e674b7b98fd912fcd5'
+  sha256 'ce0e4dab61b68ce832b700ec061f364fcddeb13fd64e84b7fb6e79aa01dd60a1'
   license :gpl # GPL v2
   pkg 'AquaSKK.pkg'
   uninstall :pkgutil => 'jp.sourceforge.inputmethod.aquaskk.pkg'


### PR DESCRIPTION
Follow an [update of upstream package](https://github.com/codefirst/aquaskk/releases/tag/4.2.7).

> - 「かな規則」より「SKK日本語FEP互換の記号入力」を設定できるようになりました。 例えば z6 で ☆ が入力できます。 ([#23](https://github.com/codefirst/aquaskk/pull/23))
> - PyCharn 4.5.4(JDK bundled)において、母音が正常に入力できない問題を暫定的に回避しました。([#24](https://github.com/codefirst/aquaskk/pull/24), [#25](https://github.com/codefirst/aquaskk/pull/25))

---

The sha-256 calculation the following.

    $ openssl dgst -sha256 ~/Downloads/AquaSKK-4.2.7.dmg
    SHA256(/Users/takeru/Downloads/AquaSKK-4.2.7.dmg)= ce0e4dab61b68ce832b700ec061f364fcddeb13fd64e84b7fb6e79aa01dd60a1