### PR TITLE
Upgrade to 4.3.2

### DIFF
--- a/Casks/aquaskk.rb
+++ b/Casks/aquaskk.rb
@@ -1,9 +1,9 @@
 cask :v1 => 'aquaskk' do
-  version '4.2.7'
+  version '4.3.2'
   url "https://github.com/codefirst/aquaskk/releases/download/#{version}/AquaSKK-#{version}.dmg"
   name 'AquaSKK'
   homepage 'https://github.com/codefirst/aquaskk'
-  sha256 'ce0e4dab61b68ce832b700ec061f364fcddeb13fd64e84b7fb6e79aa01dd60a1'
+  sha256 '1294b4e02b563410796737c86467cd321f87cc85e359a132c26ea0a2f1a344fe'
   license :gpl # GPL v2
   pkg 'AquaSKK.pkg'
   uninstall :pkgutil => 'jp.sourceforge.inputmethod.aquaskk.pkg'


### PR DESCRIPTION
Descriptions are:
- https://github.com/codefirst/aquaskk/releases/tag/4.3.2 (4.3.1 の修正)
- https://github.com/codefirst/aquaskk/releases/tag/4.3.1

> - https://github.com/codefirst/aquaskk/releases/tag/4.3.0 とほぼ同様です。
> 
> AZIKを有効している場合、「q」で「ん」が入力できるようになりました。
- https://github.com/codefirst/aquaskk/releases/tag/4.3.0

> - 拡張ローマ字入力の変換ルールを拡張したAZIK、ACTに対応。(#28, #33)
> - SKK日本語入力FEP互換の記号入力の修正: 最新のSKK日本語入力FEPにあわせ「z`」を「〆」に修正。(#34)
> ### 注意点
> - AZIK等の設定は、設定画面を閉じるときに更新される。そのため、すでにAZIKを使ってる場合は、一度設定画面を開き、閉じる必要がある。
